### PR TITLE
changed the import statement in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ yarn add rhof
 
 ```javascript
 
-const rhof = require('rhof');
+const rhof = require('@gh-conf/rhof');
 
 (async () => {
   try {


### PR DESCRIPTION
Changd import statement from
const rhof = require('rhof');
to
const rhof = require('@gh-conf/rhof');

in README.md usage as requested