### PR TITLE
Change readme install command to use npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Fetch contributors list of github repository and generate hall of fame for githu
 ## Install
 
 ```
-$ yarn add rhof
+$ npm i @gh-conf/rhof
 ```
 
 ## Usage


### PR DESCRIPTION
Changing install command in readme from `yarn` to `npm`

Issue #5 